### PR TITLE
fairer benchmark with -O2 for everyone

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ dependencies:
 - mmorph
 
 library:
+  ghc-options: -O2
   source-dirs: src
 
 executables:
@@ -54,7 +55,6 @@ benchmarks:
   too-fast-too-free-bench:
     source-dirs: bench
     main: countDown.hs
-    ghc-options: -O2
     dependencies:
     - criterion
     - free


### PR DESCRIPTION
too-fast-too-free was compiled without -O2, which put it at a
disadvantage compared to the code from the competing libraries, which is
inside the benchmark project and was thus compiled with -O2.